### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/bundles/engine/pom.xml
+++ b/bundles/engine/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/bundles/jcr/classloader/pom.xml
+++ b/bundles/jcr/classloader/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/bundles/jcr/resource/pom.xml
+++ b/bundles/jcr/resource/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
            <groupId>commons-collections</groupId>
            <artifactId>commons-collections</artifactId>
-           <version>3.2.1</version>
+           <version>3.2.2</version>
         </dependency>
 
         <!-- For the Console Plugin of the JcrResourceResolverFactoryImpl -->

--- a/bundles/scripting/jsp-taglib/pom.xml
+++ b/bundles/scripting/jsp-taglib/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/bundles/scripting/jsp/pom.xml
+++ b/bundles/scripting/jsp/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/contrib/launchpad/smx-kernel/src/main/filtered-resources/features.xml
+++ b/contrib/launchpad/smx-kernel/src/main/filtered-resources/features.xml
@@ -31,7 +31,7 @@
 		<bundle>mvn:org.apache.felix/org.apache.felix.eventadmin/1.0.0</bundle>
 		<bundle>mvn:org.apache.felix/org.apache.felix.metatype/1.0.2</bundle>
 		<bundle>mvn:org.apache.felix/org.apache.felix.scr/1.0.7-SNAPSHOT</bundle>
-		<bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
+		<bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
 		<bundle>mvn:commons-io/commons-io/1.4</bundle>
 		<bundle>mvn:commons-lang/commons-lang/2.4</bundle>
 		<bundle>mvn:org.apache.sling/org.apache.sling.commons.mime/${sling.version}</bundle>

--- a/launchpad/bundles/pom.xml
+++ b/launchpad/bundles/pom.xml
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/